### PR TITLE
Ability to login to bots without the "Bot" prefix

### DIFF
--- a/ui/login.go
+++ b/ui/login.go
@@ -267,6 +267,9 @@ func (login *Login) attemptLogin() {
 		panic("Was in state loginType=None during login attempt.")
 	case Token:
 		session, loginError := discordgo.NewWithToken(login.tokenInput.GetText())
+		if loginError != nil {
+			session,loginError = discordgo.NewWithToken("Bot " + login.tokenInput.GetText())
+		}
 		login.sessionChannel <- &loginAttempt{session, loginError}
 	case Password:
 		// Even if the login is supposed to be without two-factor-authentication, we


### PR DESCRIPTION
This is a pretty "hacky" solution, but you can make it so the end-user doesn't have to add the "Bot" prefix by doing a fallback if the token fails on user, add "Bot" infront and send the request again.

Shown here: 
```go
	case Token:
		session, loginError := discordgo.NewWithToken(login.tokenInput.GetText())
		if loginError != nil {
			session, loginError = discordgo.NewWithToken("Bot " + login.tokenInput.GetText())
		}
		login.sessionChannel <- &loginAttempt{session, loginError}
```